### PR TITLE
Extend f-log format to allow grid cell coloring, render

### DIFF
--- a/fluorine_renderer.js
+++ b/fluorine_renderer.js
@@ -1207,44 +1207,39 @@ function make_renderer() {
 
 			for (let y = 0; y < renderer.height; y++) {
 
-				let val;
-				let flog_color;
-
-				switch (renderer.prefs.grid_aesthetic) {
-					case 0:
-						val = 0;
-						break;
-					case 1:
-						val = renderer.production_list[renderer.turn][x][y] / 4;
-						break;
-					case 2:
-						val = 255 * Math.sqrt(renderer.production_list[renderer.turn][x][y] / 2048);
-						break;
-					case 3:
-						val = 255 * Math.sqrt(renderer.production_list[renderer.turn][x][y] / 1024);
-						break;
-				}
-
-				val = Math.floor(val);
-				val = Math.min(255, val);
-
-				let [i, j] = renderer.offset_adjust(x, y);
+				let color;
 
 				if (renderer.flog_colors) {
 					let key = `${renderer.turn + turn_fudge}-${x}-${y}`;
-					flog_color = renderer.flog_colors[key];
-					if (flog_color) {
-						context.fillStyle = flog_color;
-						context.fillRect(i * box_width, j * box_height, box_width, box_height);
-					}
+					color = renderer.flog_colors[key];
 				}
 
-				if (flog_color) {
-					let val_opacity = val / 255;
-					context.fillStyle = `rgba(255,255,255,${val_opacity})`;
-				} else {
-					context.fillStyle = `rgb(${val},${val},${val})`;
+				if (color === undefined) {
+					let val;
+
+					switch (renderer.prefs.grid_aesthetic) {
+						case 0:
+							val = 0;
+							break;
+						case 1:
+							val = renderer.production_list[renderer.turn][x][y] / 4;
+							break;
+						case 2:
+							val = 255 * Math.sqrt(renderer.production_list[renderer.turn][x][y] / 2048);
+							break;
+						case 3:
+							val = 255 * Math.sqrt(renderer.production_list[renderer.turn][x][y] / 1024);
+							break;
+					}
+
+					val = Math.floor(val);
+					val = Math.min(255, val);
+					color = `rgb(${val},${val},${val})`;
 				}
+
+				context.fillStyle = color;
+
+				let [i, j] = renderer.offset_adjust(x, y);
 				context.fillRect(i * box_width, j * box_height, box_width, box_height);
 			}
 		}

--- a/main.js
+++ b/main.js
@@ -597,10 +597,10 @@ An f-log is a JSON file with the following format:
     [
         {"t": 4, "x": 8, "y": 16, "msg": "Hello"},
         {"t": 12, "x": 8, "y": 15, "msg": "Hi again"},
-		{"t": 15, "x": 8, "y": 15, "msg": "This point is red", "color": "red"},
-		{"t": 15, "x": 8, "y": 16, "msg": "This point is blue", "color": "#0000FF"},
-		{"t": 15, "x": 8, "y": 17, "msg": "This point is green", "color": "rgb(0,255,0)"},
-		{"t": 15, "x": 8, "y": 18, "color": "hsl(120,100%,50%)"}
+        {"t": 15, "x": 8, "y": 15, "msg": "This point is red", "color": "red"},
+        {"t": 15, "x": 8, "y": 16, "msg": "This point is blue", "color": "#0000FF"},
+        {"t": 15, "x": 8, "y": 17, "msg": "This point is green", "color": "rgb(0,255,0)"},
+        {"t": 15, "x": 8, "y": 18, "color": "hsl(120,100%,50%)"}
     ]
 
 For convenience, Fluorine can parse an incomplete JSON array, such as:

--- a/main.js
+++ b/main.js
@@ -596,7 +596,11 @@ An f-log is a JSON file with the following format:
 
     [
         {"t": 4, "x": 8, "y": 16, "msg": "Hello"},
-        {"t": 12, "x": 8, "y": 15, "msg": "Hi again"}
+        {"t": 12, "x": 8, "y": 15, "msg": "Hi again"},
+		{"t": 15, "x": 8, "y": 15, "msg": "This point is red", "color": "red"},
+		{"t": 15, "x": 8, "y": 16, "msg": "This point is blue", "color": "#0000FF"},
+		{"t": 15, "x": 8, "y": 17, "msg": "This point is green", "color": "rgb(0,255,0)"},
+		{"t": 15, "x": 8, "y": 18, "color": "hsl(120,100%,50%)"}
     ]
 
 For convenience, Fluorine can parse an incomplete JSON array, such as:


### PR DESCRIPTION
Adds `"color": "<arbitrary css color>"` support to f-log files, and draws this color ~behind the grid~ instead of the halite value, on the correct turn, at the correct cell.

~Halite will still be rendered on top of these cells, but with opacity defined by current halite quantity, instead of rgb color value.~

Currently, the color won't be visible on cells with collisions or structures, since it's rendered behind these.

Helps with visualizing paths, ranges, etc.