### PR TITLE
Default to previous directory when opening f-log

### DIFF
--- a/main.js
+++ b/main.js
@@ -255,8 +255,12 @@ function make_main_menu() {
 				{
 					label: "Open f-log...",
 					click: () => {
-						let files = electron.dialog.showOpenDialog();
+						let files = electron.dialog.showOpenDialog({
+							defaultPath: prefs.last_flog_directory,
+							properties: ["openFile"]
+						});
 						if (files && files.length > 0) {
+							set_pref('last_flog_directory', path.dirname(files[0]));
 							windows.send("renderer", "open_flog", files[0]);
 						}
 					}

--- a/main.js
+++ b/main.js
@@ -221,8 +221,12 @@ function make_main_menu() {
 					label: "Open...",
 					accelerator: "CommandOrControl+O",
 					click: () => {
-						let files = electron.dialog.showOpenDialog();
+						let files = electron.dialog.showOpenDialog({
+							defaultPath: prefs.last_replay_directory,
+							properties: ["openFile"]
+						});
 						if (files && files.length > 0) {
+							set_pref('last_replay_directory', path.dirname(files[0]));
 							windows.send("renderer", "open", files[0]);
 							monitor_dirs(null);					// Stop monitoring if we were
 						}

--- a/modules/preferences.js
+++ b/modules/preferences.js
@@ -10,6 +10,7 @@ const default_prefs = {
     triangles_show_next: true,
     grid_aesthetic: 1,
     last_monitored_replay_dirs: [],
+    last_flog_directory: null
     // Note: Don't make this a nested structure unless you're willing to make the code below more complex.
 };
 

--- a/modules/preferences.js
+++ b/modules/preferences.js
@@ -10,7 +10,8 @@ const default_prefs = {
     triangles_show_next: true,
     grid_aesthetic: 1,
     last_monitored_replay_dirs: [],
-    last_flog_directory: null
+    last_flog_directory: null,
+    last_replay_directory: null
     // Note: Don't make this a nested structure unless you're willing to make the code below more complex.
 };
 


### PR DESCRIPTION
Sets the starting path for the f-log directory dialog to the directory of the last-opened f-log.

The preference saving could be moved to the `renderer.open_flog` method instead, if you wanted to only update the preference after parsing success.